### PR TITLE
feat: replace /feat-pr with /do-issue command

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -30,6 +30,17 @@ When the user uses /pr:
         - Use the repository name from the git remote URL
         - If the repository has been moved, use the new repository name from the move notice
         - Avoid interactive gh CLI prompts by specifying the repository explicitly with --repo flag
+        - For proper newline formatting in PR descriptions, use a here-doc like this:
+            ```bash
+            gh pr create --repo owner/repo --title "title" --body "$(cat << 'EOT'
+            Description with proper
+            newlines and formatting.
+
+            - Bullet points
+            - Work correctly
+            EOT
+            )" --base main
+            ```
 
 When the user uses /undo:
     1. Attempt to undo whatever you have just done, whether that means removing a PR, undoing a commit, or something else.

--- a/.cursorrules
+++ b/.cursorrules
@@ -10,6 +10,8 @@ When the user uses /do-issue:
     5. Ask the user for confirmation before moving on to step 6, unless the phrase was "/do-issue -y" in which case you should move on immediately
     6. Commit changes using appropriate conventional commit type
     7. Create a comprehensive PR back into the initial branch, linking to the issue
+        - Use printf to format PR descriptions with proper newlines:
+          Example: `printf "Title\n\nDescription with:\n- Bullet points\n- More points" | gh pr create --title "feat: something" --body-file -`
 
 When the user uses /issue:
     1. use the gh CLI to create an issue with - [ ] for different tasks
@@ -30,17 +32,6 @@ When the user uses /pr:
         - Use the repository name from the git remote URL
         - If the repository has been moved, use the new repository name from the move notice
         - Avoid interactive gh CLI prompts by specifying the repository explicitly with --repo flag
-        - For proper newline formatting in PR descriptions, use a here-doc like this:
-            ```bash
-            gh pr create --repo owner/repo --title "title" --body "$(cat << 'EOT'
-            Description with proper
-            newlines and formatting.
-
-            - Bullet points
-            - Work correctly
-            EOT
-            )" --base main
-            ```
 
 When the user uses /undo:
     1. Attempt to undo whatever you have just done, whether that means removing a PR, undoing a commit, or something else.

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,12 +1,15 @@
 You have been expertly engineered by leading AI scientists for the sole purpose of generating flawless source code and programs that are completely error-free. You are brilliant at reasoning and creative problem-solving, and you carefully and consistently deliver accurate, optimal solutions. 
 
-When the user uses /feat-pr:
-    1. checkout a new branch using the gh CLI (remember which branch this is made from).
-    2. Make the changes requested
-    3. Fully test changes
-    4. Ask the user for confirmation before moving on to step 4, unless the phrase was "/feat-pr -y" in which case you should move on immediately without asking for confirmation or summarizing changes
-    5. commit changes using "feat", "docs", or other identifier 
-    6. Create a comprehensive PR back into the initial branch
+When the user uses /do-issue:
+    1. If the input is not an issue number:
+        - Create a new issue using gh CLI with the provided text
+        - Store the issue number for the next steps
+    2. Checkout a new branch using the gh CLI with format `issue/[number]-[slug]`
+    3. Make the changes requested in the issue
+    4. Fully test changes
+    5. Ask the user for confirmation before moving on to step 6, unless the phrase was "/do-issue -y" in which case you should move on immediately
+    6. Commit changes using appropriate conventional commit type
+    7. Create a comprehensive PR back into the initial branch, linking to the issue
 
 When the user uses /issue:
     1. use the gh CLI to create an issue with - [ ] for different tasks


### PR DESCRIPTION
This PR updates the command structure to better integrate with GitHub issues and adds proper PR formatting.

Changes:
- Added new /do-issue command that creates and links to GitHub issues
- Removed old /feat-pr command
- Improved workflow to automatically create issues when needed
- Added printf example for proper PR description formatting

The new command supports two modes:
1. Direct issue number input
2. Text input that creates a new issue first

This change makes the workflow more GitHub-centric and improves traceability.