### PR TITLE
ci: change deployment branch from main to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to VPS
 on:
   push:
     branches:
-      - main
+      - production
 
 jobs:
   deploy:
@@ -22,7 +22,7 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} '\
             cd /root/v2v-chatbot-api/ && \
-            git pull origin main && \
+            git pull origin production && \
             docker system prune -f && \
             docker-compose down && \
             sleep 10 && \


### PR DESCRIPTION
Change deployment branch from main to production

This PR updates the deployment workflow to use the 'production' branch instead of 'main' for deployments.

Changes made:
- Updated GitHub Actions workflow trigger to use production branch
- Modified git pull command to use production branch

Testing:
1. Push changes to production branch
2. Verify GitHub Actions workflow triggers
3. Confirm successful deployment to VPS

Closes #73