### PR TITLE
fix: subscription management improvements

### DIFF
--- a/database/migrate.js
+++ b/database/migrate.js
@@ -63,12 +63,23 @@ async function planTypeMigration(dbGet, dbRun, dbAll) {
         await dbRun(`ALTER TABLE plans ADD COLUMN subscription_active INTEGER DEFAULT 0`);
     }
 
+    // Add Stripe columns to plan_type if they don't exist
+    if (!(await columnExists('plan_type', 'stripe_product_id', dbAll))) {
+        console.log('Adding stripe_product_id column to plan_type table...');
+        await dbRun(`ALTER TABLE plan_type ADD COLUMN stripe_product_id TEXT`);
+    }
+
+    if (!(await columnExists('plan_type', 'stripe_price_id', dbAll))) {
+        console.log('Adding stripe_price_id column to plan_type table...');
+        await dbRun(`ALTER TABLE plan_type ADD COLUMN stripe_price_id TEXT`);
+    }
+
     // Insert default plan types if they don't exist
     const planTypes = [
         {
             id: 0,
             name: 'Free Plan',
-            description: 'Basic features with limited usage',
+            description: 'Perfect for personal projects and testing - includes 50 monthly credits',
             monthly_credits: 50,
             cost_monthly: 0,
             cost_yearly: 0

--- a/database/stripe.js
+++ b/database/stripe.js
@@ -42,62 +42,84 @@ async function getStripeCustomer(userId) {
 async function createSubscription(customerId, planId, paymentMethodId) {
   try {
     // Get the plan details from our database
-    const plan = await dbGet('SELECT * FROM plans WHERE plan_id = ?', [planId]);
+    const plan = await dbGet(
+      `SELECT p.*, pt.stripe_product_id, pt.stripe_price_id, pt.name as plan_type_name, pt.description, pt.cost_monthly
+       FROM plans p
+       JOIN plan_type pt ON p.plan_type_id = pt.plan_type_id
+       WHERE p.plan_id = ?`,
+      [planId]
+    );
+
     if (!plan) {
       throw new Error('Plan not found');
     }
 
-    const planType = await dbGet('SELECT * FROM plan_type WHERE plan_type_id = ?', [plan.plan_type_id]);
-    if (!planType) {
-      throw new Error('Plan type not found');
-    }
-
-    // First create a product
-    const product = await stripe.products.create({
-      name: `${planType.name} - ${plan.name}`,
-      description: planType.description || `${planType.name} Subscription`
-    });
-
-    // Then create a price for the product
-    const price = await stripe.prices.create({
-      product: product.id,
-      unit_amount: planType.cost_monthly * 100, // Convert to cents
-      currency: 'usd',
-      recurring: {
-        interval: 'month'
+    // For paid plans, ensure we have a Stripe product and price
+    if (plan.cost_monthly > 0) {
+      // Create or get product if not exists
+      if (!plan.stripe_product_id) {
+        const product = await stripe.products.create({
+          name: plan.plan_type_name,
+          description: plan.description
+        });
+        await dbRun(
+          'UPDATE plan_type SET stripe_product_id = ? WHERE plan_type_id = ?',
+          [product.id, plan.plan_type_id]
+        );
+        plan.stripe_product_id = product.id;
       }
-    });
 
-    // Create subscription using the price
-    const subscription = await stripe.subscriptions.create({
-      customer: customerId,
-      items: [{ price: price.id }],
-      default_payment_method: paymentMethodId
-    });
+      // Create or get price if not exists
+      if (!plan.stripe_price_id) {
+        const price = await stripe.prices.create({
+          product: plan.stripe_product_id,
+          unit_amount: plan.cost_monthly * 100, // Convert to cents
+          currency: 'usd',
+          recurring: {
+            interval: 'month'
+          }
+        });
+        await dbRun(
+          'UPDATE plan_type SET stripe_price_id = ? WHERE plan_type_id = ?',
+          [price.id, plan.plan_type_id]
+        );
+        plan.stripe_price_id = price.id;
+      }
 
-    // Store subscription in our database
-    await dbRun(
-      `INSERT INTO stripe_subscriptions 
-       (customer_id, stripe_subscription_id, plan_id, status, 
-        current_period_start, current_period_end) 
-       VALUES (?, ?, ?, ?, datetime(?,'unixepoch'), datetime(?,'unixepoch'))`,
-      [
-        customerId,
-        subscription.id,
-        planId,
-        subscription.status,
-        subscription.current_period_start,
-        subscription.current_period_end
-      ]
-    );
+      // Create subscription using the price
+      const subscription = await stripe.subscriptions.create({
+        customer: customerId,
+        items: [{ price: plan.stripe_price_id }],
+        default_payment_method: paymentMethodId
+      });
 
-    // Update plan's subscription status to active
-    await dbRun(
-      `UPDATE plans SET subscription_active = 1 WHERE plan_id = ?`,
-      [planId]
-    );
+      // Store subscription in our database
+      await dbRun(
+        `INSERT INTO stripe_subscriptions 
+         (customer_id, stripe_subscription_id, plan_id, status, 
+          current_period_start, current_period_end) 
+         VALUES (?, ?, ?, ?, datetime(?,'unixepoch'), datetime(?,'unixepoch'))`,
+        [
+          customerId,
+          subscription.id,
+          planId,
+          subscription.status,
+          subscription.current_period_start,
+          subscription.current_period_end
+        ]
+      );
 
-    return subscription;
+      // Update plan's subscription status to active
+      await dbRun(
+        `UPDATE plans SET subscription_active = 1 WHERE plan_id = ?`,
+        [planId]
+      );
+
+      return subscription;
+    } else {
+      // For free plans, just return success
+      return { status: 'active', free_plan: true };
+    }
   } catch (error) {
     console.error('Error creating subscription:', error);
     throw error;

--- a/website-api/payments.js
+++ b/website-api/payments.js
@@ -54,6 +54,9 @@ router.post('/create-subscription', authMiddleware, async (req, res) => {
       return res.status(400).json({ error: 'Customer not found' });
     }
 
+    // Cancel any existing active subscriptions for this plan
+    await cancelActiveSubscriptions(planId);
+
     // Add the payment method to the customer if it's new
     await addPaymentMethod(customer.stripe_customer_id, paymentMethodId, true);
 


### PR DESCRIPTION
fix: subscription management improvements

Changes:
- Fix Stripe product/price creation to reuse existing ones instead of creating new ones per subscription
- Add proper subscription cancellation when changing plans
- Handle free plan transitions correctly
- Add Stripe product/price IDs to plan_type table

Testing:
1. Create a paid subscription - should see one product/price in Stripe
2. Create another subscription of same type - should reuse product/price
3. Downgrade to free - should see subscription canceled in Stripe
4. Upgrade to different paid plan - should see new subscription with different product/price
5. Change between paid plans - should see old subscription canceled