### PR TITLE
feat: add bulk testing feature with credit warning and referenced pages

### DIFF
--- a/chatbot-api/builtInTools.js
+++ b/chatbot-api/builtInTools.js
@@ -116,7 +116,7 @@ async function readPageContent(params, metadata) {
         const bestMatch = scores.every(score => score.count === 0) ? pathUrls[0] : scores[0].url;
 
         // Construct the message
-        const message = `You entered ${params.path} which is either not a full path or not in the list of paths. Please try again using one of the full paths listed below. Here are all available paths: ${pathUrls.join(", ")}, the system thinks you may be most interested in: ${bestMatch}`;
+        const message = `You entered ${params.path} which the system assumed to mean ${path}.  Please try again using a full path (e.g. www.example.com/page instead of /page). Here are all available paths: ${pathUrls.join(", ")}, the system also thinks you may be interested in: ${bestMatch}`;
         console.log(message);
         return message;
     }

--- a/chatbot-api/builtInTools.js
+++ b/chatbot-api/builtInTools.js
@@ -14,7 +14,7 @@ tools = [
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "The path to read from, for example '/' for the landing page of the website.",
+                        "description": "The full path of the page to read, e.g. https://www.example.com/page",
                     }
                 },
                 "required": ["path"],

--- a/chatbot-api/builtInTools.js
+++ b/chatbot-api/builtInTools.js
@@ -113,10 +113,17 @@ async function readPageContent(params, metadata) {
         scores.sort((a, b) => b.count - a.count || pathUrls.indexOf(a.url) - pathUrls.indexOf(b.url));
 
         // Get the best match, default to the first element if all scores are 0
-        const bestMatch = scores.every(score => score.count === 0) ? pathUrls[0] : scores[0].url;
+        let bestMatch = scores.every(score => score.count === 0) ? pathUrls[0] : scores[0].url;
+
+        // if one path ends with the input path, return that path
+        for (let i = 0; i < pathUrls.length; i++) {
+            if (pathUrls[i].endsWith(params.path)) {
+                bestMatch = pathUrls[i];
+            }
+        }
 
         // Construct the message
-        const message = `You entered ${params.path} which the system assumed to mean ${path}.  Please try again using a full path (e.g. www.example.com/page instead of /page). Here are all available paths: ${pathUrls.join(", ")}, the system also thinks you may be interested in: ${bestMatch}`;
+        const message = `You entered ${params.path}.  Please try again using a full path (e.g. www.example.com/page instead of just /page). The system also thinks you may be interested in: ${bestMatch}`;
         console.log(message);
         return message;
     }

--- a/chatbot-api/builtInTools.js
+++ b/chatbot-api/builtInTools.js
@@ -1,4 +1,4 @@
-const {db} = require('../database/database.js');
+const {db, dbAll} = require('../database/database.js');
 const { getPageByUrlAndWebsiteId } = require('../database/pages.js');
 const {getWebsiteById} = require('../database/websites.js');
 const wsManager = require('./wsManager');
@@ -74,7 +74,13 @@ async function readPageContent(params, metadata) {
             return page.content;
         }
         console.warn('No information found for path', path);
-        return `No information found for path ${path}.  Are you sure you entered it correctly?`;
+        // get all available paths
+        let paths = [];
+        console.log(metadata.websiteId)
+        paths = await dbAll('SELECT url FROM page WHERE website_id = ?', [metadata.websiteId]);
+        console.log(paths)
+        const pathUrls = paths.map(path => path.url);
+        return `Please try again using one of the full paths listed below.  Here are all available paths: ${pathUrls.join(", ")}, were you looking for one of these?`;
     }
 }
 

--- a/chatbot-api/builtInTools.js
+++ b/chatbot-api/builtInTools.js
@@ -74,13 +74,34 @@ async function readPageContent(params, metadata) {
             return page.content;
         }
         console.warn('No information found for path', path);
-        // get all available paths
+
+        // Get all available paths
         let paths = [];
-        console.log(metadata.websiteId)
+        console.log(metadata.websiteId);
         paths = await dbAll('SELECT url FROM page WHERE website_id = ?', [metadata.websiteId]);
-        console.log(paths)
+
+        // Extract URLs from the database result
         const pathUrls = paths.map(path => path.url);
-        return `Please try again using one of the full paths listed below.  Here are all available paths: ${pathUrls.join(", ")}, were you looking for one of these?`;
+
+        // Calculate the most similar path based on substring
+        const paramsPath = params.path.slice(1).toLowerCase(); // Normalize for case-insensitive matching
+
+        // Count occurrences of the input substring in each URL
+        const scores = pathUrls.map(url => ({
+            url,
+            count: (url.toLowerCase().match(new RegExp(paramsPath, 'g')) || []).length // Count occurrences
+        }));
+
+        // Sort paths by count (descending) and resolve ties by original order
+        scores.sort((a, b) => b.count - a.count || pathUrls.indexOf(a.url) - pathUrls.indexOf(b.url));
+
+        // Get the best match, default to the first element if all scores are 0
+        const bestMatch = scores.every(score => score.count === 0) ? pathUrls[0] : scores[0].url;
+
+        // Construct the message
+        const message = `You entered ${params.path} which is either not a full path or not in the list of paths. Please try again using one of the full paths listed below. Here are all available paths: ${pathUrls.join(", ")}, the system thinks you may be most interested in: ${bestMatch}`;
+        console.log(message);
+        return message;
     }
 }
 

--- a/development-ui/styles.css
+++ b/development-ui/styles.css
@@ -351,3 +351,100 @@ button {
     min-width: 120px;
     text-align: center;
 }
+
+/* Bulk Testing Styles */
+.bulk-testing-section {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background-color: #f8f9fa;
+    border-radius: 8px;
+}
+
+.bulk-testing-section h2 {
+    margin-top: 0;
+    color: #333;
+}
+
+.file-upload {
+    display: flex;
+    gap: 1rem;
+    margin: 1rem 0;
+    align-items: center;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 20px;
+    background-color: #e9ecef;
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 1rem 0;
+}
+
+#progressFill {
+    height: 100%;
+    background-color: #007bff;
+    transition: width 0.3s ease;
+}
+
+#progressText {
+    text-align: center;
+    color: #666;
+    margin: 0.5rem 0;
+}
+
+.test-result {
+    background-color: white;
+    padding: 1rem;
+    margin: 1rem 0;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.test-result h4 {
+    margin: 0 0 0.5rem 0;
+    color: #333;
+}
+
+.test-result p {
+    margin: 0;
+    color: #666;
+    white-space: pre-wrap;
+}
+
+#downloadBtn {
+    margin-bottom: 1rem;
+}
+
+.button-group {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+/* General button styles */
+button {
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    background-color: #007bff;
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+input[type="file"] {
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background-color: white;
+}

--- a/development-ui/styles.css
+++ b/development-ui/styles.css
@@ -356,13 +356,14 @@ button {
 .bulk-testing-section {
     margin-top: 2rem;
     padding: 1.5rem;
-    background-color: #f8f9fa;
+    background-color: #1a2c44;
     border-radius: 8px;
+    border: 1px solid #00ffff;
 }
 
 .bulk-testing-section h2 {
     margin-top: 0;
-    color: #333;
+    color: #00ffff;
 }
 
 .file-upload {
@@ -375,51 +376,57 @@ button {
 .progress-bar {
     width: 100%;
     height: 20px;
-    background-color: #e9ecef;
+    background-color: #0f1929;
     border-radius: 10px;
     overflow: hidden;
     margin: 1rem 0;
+    border: 1px solid #00ffff;
 }
 
 #progressFill {
     height: 100%;
-    background-color: #007bff;
+    background-color: #00ffff;
     transition: width 0.3s ease;
 }
 
 #progressText {
     text-align: center;
-    color: #666;
+    color: #ffffff;
     margin: 0.5rem 0;
 }
 
 .test-result {
-    background-color: white;
+    background-color: #233554;
     padding: 1rem;
     margin: 1rem 0;
     border-radius: 4px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    border: 1px solid #00ffff;
 }
 
 .test-result h4 {
     margin: 0 0 0.5rem 0;
-    color: #333;
+    color: #00ffff;
 }
 
 .test-result p {
     margin: 0;
-    color: #666;
+    color: #ffffff;
     white-space: pre-wrap;
 }
 
-#downloadBtn {
+.download-buttons {
+    display: flex;
+    gap: 1rem;
     margin-bottom: 1rem;
 }
 
-.button-group {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 2rem;
+input[type="file"] {
+    padding: 0.5rem;
+    border: 1px solid #00ffff;
+    border-radius: 4px;
+    background-color: #0f1929;
+    color: #ffffff;
 }
 
 /* General button styles */
@@ -440,11 +447,4 @@ button:hover {
 button:disabled {
     background-color: #ccc;
     cursor: not-allowed;
-}
-
-input[type="file"] {
-    padding: 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    background-color: white;
 }

--- a/development-ui/styles.css
+++ b/development-ui/styles.css
@@ -415,6 +415,38 @@ button {
     white-space: pre-wrap;
 }
 
+.references {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(0, 255, 255, 0.2);
+}
+
+.references h5 {
+    color: #00ffff;
+    margin: 0 0 0.5rem 0;
+    font-size: 0.9em;
+}
+
+.references ul {
+    margin: 0;
+    padding-left: 1.5rem;
+    list-style-type: none;
+}
+
+.references li {
+    color: #ffffff;
+    font-size: 0.9em;
+    margin-bottom: 0.25rem;
+    position: relative;
+}
+
+.references li::before {
+    content: "•";
+    color: #00ffff;
+    position: absolute;
+    left: -1rem;
+}
+
 .download-buttons {
     display: flex;
     gap: 1rem;

--- a/development-ui/test-chatbot.html
+++ b/development-ui/test-chatbot.html
@@ -11,12 +11,39 @@
 
     <p>Enter a message below to chat with the chatbot. If you're happy with the results, click the "Deploy Chatbot" button to move on to the final step. Otherwise, you can always go back and edit the chatbot's settings to make sure it works the way you want.</p>
     
-    <button onclick="window.location.href = '/chatbot-setup.html'">Edit Chatbot</button>
-    <button onclick="window.location.href = '/deploy-chatbot.html'">Deploy Chatbot</button>
+    <div class="button-group">
+        <button onclick="window.location.href = '/chatbot-setup.html'">Edit Chatbot</button>
+        <button onclick="window.location.href = '/deploy-chatbot.html'">Deploy Chatbot</button>
+    </div>
+
+    <div class="bulk-testing-section">
+        <h2>Bulk Testing</h2>
+        <p>Upload a .txt file with one question per line (maximum 100 questions) to test multiple questions at once.</p>
+        
+        <div class="file-upload">
+            <input type="file" id="questionsFile" accept=".txt" />
+            <button onclick="startBulkTest()" id="startTestBtn">Start Bulk Test</button>
+        </div>
+
+        <div id="testProgress" style="display: none;">
+            <div class="progress-bar">
+                <div id="progressFill" style="width: 0%"></div>
+            </div>
+            <p id="progressText">Testing question 0/0</p>
+        </div>
+
+        <div id="testResults" style="display: none;">
+            <h3>Test Results</h3>
+            <button onclick="downloadResults()" id="downloadBtn">Download Results (CSV)</button>
+            <div id="resultsContainer"></div>
+        </div>
+    </div>
 
     <script>
         // Get planId from URL
         const planId = new URLSearchParams(window.location.search).get('planId');
+        let chatbotId = null;
+
         if (!planId) {
             console.error('No planId provided in URL');
         } else {
@@ -31,7 +58,7 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    const chatbotId = data.chatbot.chatbot_id;
+                    chatbotId = data.chatbot.chatbot_id;
                     // Add the component script with the chatbot ID
                     const script = document.createElement('script');
                     script.src = '/chatbot/api/frontend/component.js';
@@ -44,6 +71,115 @@
             .catch(error => {
                 console.error('Error:', error);
             });
+        }
+
+        // Bulk testing functionality
+        let testResults = [];
+
+        async function validateFile(file) {
+            const text = await file.text();
+            const lines = text.split('\n').filter(line => line.trim());
+            
+            if (lines.length > 100) {
+                throw new Error('File contains more than 100 questions');
+            }
+            
+            return lines;
+        }
+
+        async function startBulkTest() {
+            const fileInput = document.getElementById('questionsFile');
+            const file = fileInput.files[0];
+            
+            if (!file) {
+                alert('Please select a file first');
+                return;
+            }
+            
+            if (!file.name.endsWith('.txt')) {
+                alert('Please upload a .txt file');
+                return;
+            }
+
+            try {
+                const questions = await validateFile(file);
+                document.getElementById('testProgress').style.display = 'block';
+                document.getElementById('startTestBtn').disabled = true;
+                testResults = [];
+
+                for (let i = 0; i < questions.length; i++) {
+                    const question = questions[i].trim();
+                    if (!question) continue;
+
+                    // Update progress
+                    document.getElementById('progressText').textContent = `Testing question ${i + 1}/${questions.length}`;
+                    document.getElementById('progressFill').style.width = `${((i + 1) / questions.length) * 100}%`;
+
+                    try {
+                        const response = await fetch(`/chatbot/api/chat/${chatbotId}`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ message: question, chatId: -1 })
+                        });
+
+                        if (!response.ok) {
+                            throw new Error(`HTTP error! status: ${response.status}`);
+                        }
+
+                        const data = await response.json();
+                        testResults.push({
+                            question: question,
+                            answer: data.message
+                        });
+
+                        // Update results display
+                        updateResultsDisplay();
+                    } catch (error) {
+                        console.error('Error testing question:', error);
+                        testResults.push({
+                            question: question,
+                            answer: 'Error: Failed to get response'
+                        });
+                    }
+                }
+
+                document.getElementById('startTestBtn').disabled = false;
+                document.getElementById('testResults').style.display = 'block';
+            } catch (error) {
+                alert(error.message);
+                document.getElementById('startTestBtn').disabled = false;
+            }
+        }
+
+        function updateResultsDisplay() {
+            const container = document.getElementById('resultsContainer');
+            container.innerHTML = testResults.map((result, index) => `
+                <div class="test-result">
+                    <h4>Q${index + 1}: ${result.question}</h4>
+                    <p>${result.answer}</p>
+                </div>
+            `).join('');
+        }
+
+        function downloadResults() {
+            let csv = 'Question,Answer\n';
+            
+            testResults.forEach(result => {
+                // Escape quotes and commas in the text
+                const escapedQuestion = result.question.replace(/"/g, '""');
+                const escapedAnswer = result.answer.replace(/"/g, '""');
+                csv += `"${escapedQuestion}","${escapedAnswer}"\n`;
+            });
+
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.setAttribute('hidden', '');
+            a.setAttribute('href', url);
+            a.setAttribute('download', 'chatbot_test_results.csv');
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
         }
     </script>
 </body>

--- a/development-ui/test-chatbot.html
+++ b/development-ui/test-chatbot.html
@@ -34,7 +34,10 @@
 
         <div id="testResults" style="display: none;">
             <h3>Test Results</h3>
-            <button onclick="downloadResults()" id="downloadBtn">Download Results (CSV)</button>
+            <div class="download-buttons">
+                <button onclick="downloadResults('csv')" id="downloadCsvBtn">Download Results (CSV)</button>
+                <button onclick="downloadResults('txt')" id="downloadTxtBtn">Download Results (Text)</button>
+            </div>
             <div id="resultsContainer"></div>
         </div>
     </div>
@@ -103,6 +106,18 @@
 
             try {
                 const questions = await validateFile(file);
+                const numQuestions = questions.length;
+                
+                // Show credit usage warning
+                const proceed = confirm(
+                    `This bulk test will use ${numQuestions} credits from your plan ` +
+                    `(1 credit per question). \n\nDo you want to proceed with testing ${numQuestions} questions?`
+                );
+                
+                if (!proceed) {
+                    return;
+                }
+
                 document.getElementById('testProgress').style.display = 'block';
                 document.getElementById('startTestBtn').disabled = true;
                 testResults = [];
@@ -127,6 +142,13 @@
                         }
 
                         const data = await response.json();
+                        
+                        // Check if we ran out of credits
+                        if (data.error && data.error.includes('out of credits')) {
+                            alert('Plan out of credits. Testing stopped.');
+                            break;
+                        }
+
                         testResults.push({
                             question: question,
                             answer: data.message
@@ -161,22 +183,37 @@
             `).join('');
         }
 
-        function downloadResults() {
-            let csv = 'Question,Answer\n';
-            
-            testResults.forEach(result => {
-                // Escape quotes and commas in the text
-                const escapedQuestion = result.question.replace(/"/g, '""');
-                const escapedAnswer = result.answer.replace(/"/g, '""');
-                csv += `"${escapedQuestion}","${escapedAnswer}"\n`;
-            });
+        function downloadResults(format) {
+            if (format === 'csv') {
+                let csv = 'Question,Answer\n';
+                
+                testResults.forEach(result => {
+                    // Escape quotes and commas in the text
+                    const escapedQuestion = result.question.replace(/"/g, '""');
+                    const escapedAnswer = result.answer.replace(/"/g, '""');
+                    csv += `"${escapedQuestion}","${escapedAnswer}"\n`;
+                });
 
-            const blob = new Blob([csv], { type: 'text/csv' });
+                downloadFile(csv, 'chatbot_test_results.csv', 'text/csv');
+            } else if (format === 'txt') {
+                let text = 'CHATBOT TEST RESULTS\n\n';
+                
+                testResults.forEach((result, index) => {
+                    text += `Question ${index + 1}: ${result.question}\n`;
+                    text += `Answer: ${result.answer}\n\n`;
+                });
+
+                downloadFile(text, 'chatbot_test_results.txt', 'text/plain');
+            }
+        }
+
+        function downloadFile(content, filename, type) {
+            const blob = new Blob([content], { type: type });
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.setAttribute('hidden', '');
             a.setAttribute('href', url);
-            a.setAttribute('download', 'chatbot_test_results.csv');
+            a.setAttribute('download', filename);
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);

--- a/development-ui/test-chatbot.html
+++ b/development-ui/test-chatbot.html
@@ -149,9 +149,13 @@
                             break;
                         }
 
+                        // Extract referenced pages from the answer
+                        const referencedPages = extractReferencedPages(data.message);
+
                         testResults.push({
                             question: question,
-                            answer: data.message
+                            answer: data.message,
+                            references: referencedPages
                         });
 
                         // Update results display
@@ -160,7 +164,8 @@
                         console.error('Error testing question:', error);
                         testResults.push({
                             question: question,
-                            answer: 'Error: Failed to get response'
+                            answer: 'Error: Failed to get response',
+                            references: []
                         });
                     }
                 }
@@ -173,25 +178,48 @@
             }
         }
 
+        function extractReferencedPages(message) {
+            // Look for URLs in the message
+            const urlRegex = /https?:\/\/[^\s<>"]+/g;
+            const urls = message.match(urlRegex) || [];
+            
+            // Look for page references in square brackets
+            const bracketRegex = /\[(.*?)\]/g;
+            const bracketMatches = [...message.matchAll(bracketRegex)].map(match => match[1]);
+            
+            // Combine and deduplicate references
+            const allReferences = [...new Set([...urls, ...bracketMatches])];
+            return allReferences;
+        }
+
         function updateResultsDisplay() {
             const container = document.getElementById('resultsContainer');
             container.innerHTML = testResults.map((result, index) => `
                 <div class="test-result">
                     <h4>Q${index + 1}: ${result.question}</h4>
                     <p>${result.answer}</p>
+                    ${result.references.length > 0 ? `
+                        <div class="references">
+                            <h5>Referenced Pages:</h5>
+                            <ul>
+                                ${result.references.map(ref => `<li>${ref}</li>`).join('')}
+                            </ul>
+                        </div>
+                    ` : ''}
                 </div>
             `).join('');
         }
 
         function downloadResults(format) {
             if (format === 'csv') {
-                let csv = 'Question,Answer\n';
+                let csv = 'Question,Answer,References\n';
                 
                 testResults.forEach(result => {
                     // Escape quotes and commas in the text
                     const escapedQuestion = result.question.replace(/"/g, '""');
                     const escapedAnswer = result.answer.replace(/"/g, '""');
-                    csv += `"${escapedQuestion}","${escapedAnswer}"\n`;
+                    const escapedReferences = result.references.join('; ').replace(/"/g, '""');
+                    csv += `"${escapedQuestion}","${escapedAnswer}","${escapedReferences}"\n`;
                 });
 
                 downloadFile(csv, 'chatbot_test_results.csv', 'text/csv');
@@ -200,7 +228,14 @@
                 
                 testResults.forEach((result, index) => {
                     text += `Question ${index + 1}: ${result.question}\n`;
-                    text += `Answer: ${result.answer}\n\n`;
+                    text += `Answer: ${result.answer}\n`;
+                    if (result.references.length > 0) {
+                        text += 'Referenced Pages:\n';
+                        result.references.forEach(ref => {
+                            text += `- ${ref}\n`;
+                        });
+                    }
+                    text += '\n';
                 });
 
                 downloadFile(text, 'chatbot_test_results.txt', 'text/plain');


### PR DESCRIPTION
Add bulk testing feature with credit warning and referenced pages

This PR adds several enhancements to the chatbot testing page:

- Add ability to upload and test multiple questions at once
- Show credit usage warning before starting bulk test
- Track and display pages referenced by the AI in responses
- Add both CSV and text file download options
- Update styling to match dark theme

Testing Steps:
1. Upload a text file with multiple questions (test_questions.txt provided)
2. Verify credit warning appears with correct count
3. Check that progress bar updates during testing
4. Verify referenced pages are shown for each answer
5. Test both CSV and text file downloads
6. Confirm dark theme styling is consistent

Closes #90